### PR TITLE
Project micro-to-macro fabric

### DIFF
--- a/lib/atc/LammpsInterface.h
+++ b/lib/atc/LammpsInterface.h
@@ -33,6 +33,7 @@ namespace LAMMPS_NS {
   class Compute;
   class ComputePEAtom;
   class ComputeStressAtom;
+  class ComputeFabricAtom;
   class ComputeCentroAtom;
   class ComputeCNAAtom;
   class ComputeCoordAtom;
@@ -92,7 +93,7 @@ class LammpsInterface {
   };
 
   // Provides a struct for easily passing/recovering data about SparseMats
-  struct SparseMatInfo { 
+  struct SparseMatInfo {
     INDEX rows;
     INDEX cols;
     INDEX rowsCRS;
@@ -106,9 +107,9 @@ class LammpsInterface {
   static void Destroy();
 
   /** Set lammps pointer */
-  void set_lammps(LAMMPS_NS::LAMMPS * lammps) 
-  { 
-    lammps_ = lammps; 
+  void set_lammps(LAMMPS_NS::LAMMPS * lammps)
+  {
+    lammps_ = lammps;
     MPI_Comm_rank(lammps_->world, & commRank_);
     MPI_Comm_size(lammps_->world, & commSize_);
   }
@@ -170,7 +171,7 @@ class LammpsInterface {
   void sparse_allsum(SparseMatrix<double> &toShare) const
 #ifdef ISOLATE_FE
   {
-    MPI_Wrappers::sparse_allsum(lammps_->world, toShare); 
+    MPI_Wrappers::sparse_allsum(lammps_->world, toShare);
   }
 #else
 ;
@@ -237,14 +238,14 @@ class LammpsInterface {
 
   void print_debug(std::string msg="") const
   {
-    std::cout << "rank " << comm_rank() << " " << msg << "\n" << std::flush; 
+    std::cout << "rank " << comm_rank() << " " << msg << "\n" << std::flush;
     barrier();
   }
 
   int comm_rank(void) const { return commRank_;}
   int comm_size(void) const { return commSize_;}
   bool rank_zero(void) const { return (commRank_==0);}
-  bool serial(void) const { 
+  bool serial(void) const {
     int size = 1; MPI_Comm_size(lammps_->world,&size);
     return (size==1);
   }
@@ -256,12 +257,12 @@ class LammpsInterface {
     std::stringstream full_msg;
     if (serial()) {
       full_msg << " ATC: " << msg << "\n";
-    } 
+    }
     else {
       full_msg << " ATC: P" << me << ", " << msg << "\n";
     }
     std::string mesg = full_msg.str();
-    
+
     if (lammps_->screen)  fprintf(lammps_->screen, "%s",mesg.c_str());
     if (lammps_->logfile) fprintf(lammps_->logfile,"%s",mesg.c_str());
   }
@@ -288,7 +289,7 @@ class LammpsInterface {
     std::stringstream full_msg;
     if (serial()) {
       full_msg << " ATC: " << tag << data << "\n";
-    } 
+    }
     else {
       int commSize = comm_size();
       double recv[commSize];
@@ -335,13 +336,13 @@ class LammpsInterface {
   int nghost() const;
   int nmax() const;
   int ntypes() const;
-  double ** xatom() const; 
-  double ** vatom() const; 
-  double ** fatom() const; 
-  const int * atom_mask() const; 
+  double ** xatom() const;
+  double ** vatom() const;
+  double ** fatom() const;
+  const int * atom_mask() const;
   int * atom_mask();
-  int * atom_type() const; 
-  int * atom_tag() const; 
+  int * atom_type() const;
+  int * atom_tag() const;
   int * atom_to_molecule() const;
   int * num_bond() const;
   int ** bond_atom() const;
@@ -417,7 +418,7 @@ class LammpsInterface {
   }
   /*@}*/
   void minimum_image(double & dx, double & dy, double & dz) const;
-  void closest_image(const double * const xi, const double * const xj, double * const xjImage) const; 
+  void closest_image(const double * const xi, const double * const xj, double * const xjImage) const;
 
 
   /** \name Methods that interface with Update class */
@@ -426,7 +427,7 @@ class LammpsInterface {
   //double minimize_energy() { return lammps_->update->minimize->ecurrent; }
   double minimize_energy() const { return lammps_->update->minimize->eprevious; }
   /*@}*/
-  
+
   /** \name Methods that interface with Lattice class */
   /*@{*/
   double xlattice() const;
@@ -462,12 +463,12 @@ class LammpsInterface {
   // interface to "single"
   double pair_force(int i, int j, double rsq, double& fmag_over_rmag) const; // pair class
   double pair_force(int n, double rsq, double& fmag_over_rmag) const; // bond class
-  double pair_force(std::map< std::pair< int,int >,int >::const_iterator itr, double rsq, double& fmag_over_rmag, int nbonds = 0) const; 
-  double pair_force(std::pair< std::pair< int,int >,int > apair, double rsq, double& fmag_over_rmag, int nbonds = 0) const; 
+  double pair_force(std::map< std::pair< int,int >,int >::const_iterator itr, double rsq, double& fmag_over_rmag, int nbonds = 0) const;
+  double pair_force(std::pair< std::pair< int,int >,int > apair, double rsq, double& fmag_over_rmag, int nbonds = 0) const;
   double pair_cutoff() const;
   void pair_reinit() const;
   int single_enable() const;
-  LAMMPS_NS::PairEAM * pair_eam(void) const; 
+  LAMMPS_NS::PairEAM * pair_eam(void) const;
   double bond_stiffness(int i, int j, double rsq) const;
   /*@}*/
 
@@ -475,12 +476,12 @@ class LammpsInterface {
   /*@{*/
   int delete_atom(int id) const;
   int insert_atom(int type, int mask, double* x, double* v, double q = 0) const;
-  double shortrange_energy(double *x, int type, int id = -1, 
+  double shortrange_energy(double *x, int type, int id = -1,
     double max = big_) const;
   int reset_ghosts(int dn) const;
   double shortrange_energy(int id, double max = big_) const;
   POTENTIAL potential(void) const;
-  int type_to_groupbit(int itype) const; 
+  int type_to_groupbit(int itype) const;
   int      change_type(int itype, int jtype) const;
   int      count_type(int itype) const;
   bool     epsilons(int type, POTENTIAL p, double * epsilons) const;
@@ -524,7 +525,7 @@ class LammpsInterface {
       j %= n;
     }
     return factor_coul;
-  } 
+  }
   /*@}*/
 
   /** \name Methods that interface with Group class */
@@ -588,8 +589,8 @@ class LammpsInterface {
   /*@{*/
   int   bond_list_length() const;
   int ** bond_list() const; // direct access
-  int * bond_list(int n) const { return bond_list()[n];} 
-  int   bond_list_i(int n) const    { return bond_list(n)[0];} 
+  int * bond_list(int n) const { return bond_list()[n];}
+  int   bond_list_i(int n) const    { return bond_list(n)[0];}
   int   bond_list_j(int n) const    { return bond_list(n)[1];}
   int   bond_list_type(int n) const { return bond_list(n)[2];}
   /*@}*/
@@ -611,11 +612,12 @@ class LammpsInterface {
   /*@}*/
 
   /** \name Methods that interface with compute class */
-  enum COMPUTE_INVOKED 
+  enum COMPUTE_INVOKED
    {INVOKED_SCALAR=1,INVOKED_VECTOR=2,INVOKED_ARRAY=4,INVOKED_PERATOM=8};
-  enum PER_ATOM_COMPUTE 
+  enum PER_ATOM_COMPUTE
    {PE_ATOM,
     STRESS_ATOM,
+    FABRIC_ATOM,
     CENTRO_ATOM,
     CNA_ATOM,
     COORD_ATOM,
@@ -637,7 +639,7 @@ class LammpsInterface {
   std::string compute_pe_name(void) const {return atomPeNameBase_;};//  +fix_id();}; enables unique names, if desired
   void     computes_clearstep(void) const {lammps_->modify->clearstep_compute();};
   /*@}*/
- 
+
 
 
   /** Return lammps pointer -- only as a last resort! */

--- a/src/compute_fabric_atom.cpp
+++ b/src/compute_fabric_atom.cpp
@@ -1,0 +1,280 @@
+/* ----------------------------------------------------------------------
+    This is the
+
+    ██╗     ██╗ ██████╗  ██████╗  ██████╗ ██╗  ██╗████████╗███████╗
+    ██║     ██║██╔════╝ ██╔════╝ ██╔════╝ ██║  ██║╚══██╔══╝██╔════╝
+    ██║     ██║██║  ███╗██║  ███╗██║  ███╗███████║   ██║   ███████╗
+    ██║     ██║██║   ██║██║   ██║██║   ██║██╔══██║   ██║   ╚════██║
+    ███████╗██║╚██████╔╝╚██████╔╝╚██████╔╝██║  ██║   ██║   ███████║
+    ╚══════╝╚═╝ ╚═════╝  ╚═════╝  ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝®
+
+    DEM simulation engine, released by
+    DCS Computing Gmbh, Linz, Austria
+    http://www.dcs-computing.com, office@dcs-computing.com
+
+    LIGGGHTS® is part of CFDEM®project:
+    http://www.liggghts.com | http://www.cfdem.com
+
+    Core developer and main author:
+    Christoph Kloss, christoph.kloss@dcs-computing.com
+
+    LIGGGHTS® is open-source, distributed under the terms of the GNU Public
+    License, version 2 or later. It is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. You should have
+    received a copy of the GNU General Public License along with LIGGGHTS®.
+    If not, see http://www.gnu.org/licenses . See also top-level README
+    and LICENSE files.
+
+    LIGGGHTS® and CFDEM® are registered trade marks of DCS Computing GmbH,
+    the producer of the LIGGGHTS® software and the CFDEM®coupling software
+    See http://www.cfdem.com/terms-trademark-policy for details.
+
+-------------------------------------------------------------------------
+    Contributing author and copyright for this file:
+    This file is from LAMMPS, but has been modified. Copyright for
+    modification:
+
+    Copyright 2012-     DCS Computing GmbH, Linz
+    Copyright 2009-2012 JKU Linz
+
+    Copyright of original file:
+    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+    http://lammps.sandia.gov, Sandia National Laboratories
+    Steve Plimpton, sjplimp@sandia.gov
+
+    Copyright (2003) Sandia Corporation.  Under the terms of Contract
+    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+    certain rights in this software.  This software is distributed under
+    the GNU General Public License.
+------------------------------------------------------------------------- */
+
+#include <stdlib.h>
+#include <string.h>
+#include "compute_fabric_atom.h"
+#include "atom.h"
+#include "update.h"
+#include "comm.h"
+#include "force.h"
+#include "pair.h"
+#include "bond.h"
+#include "angle.h"
+#include "dihedral.h"
+#include "improper.h"
+#include "kspace.h"
+#include "modify.h"
+#include "fix.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeFabricAtom::ComputeFabricAtom(LAMMPS *lmp, int &iarg, int narg, char **arg) :
+  Compute(lmp, iarg, narg, arg)
+{
+  if (narg < iarg) error->all(FLERR,"Illegal compute fabric/atom command");
+
+  peratom_flag = 1;
+  size_peratom_cols = 9;
+  pressatomflag = 1;
+  timeflag = 1;
+  comm_forward = 9;
+  comm_reverse = 9;
+
+  if (narg == iarg) {
+    pairflag = 1;
+  } else {
+    pairflag = 0;
+    while (iarg < narg) {
+      if (strcmp(arg[iarg],"pair") == 0) pairflag = 1;
+      else if (strcmp(arg[iarg],"virial") == 0) {
+        pairflag = 1;
+      } else error->all(FLERR,"Illegal compute fabric/atom command");
+      iarg++;
+    }
+  }
+
+  nmax = 0;
+  fabric = NULL;
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeFabricAtom::~ComputeFabricAtom()
+{
+  memory->destroy(fabric);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeFabricAtom::compute_peratom()
+{
+  int i,j;
+  double onemass;
+
+  invoked_peratom = update->ntimestep;
+  if (update->vflag_atom != invoked_peratom)
+    error->all(FLERR,"Per-atom fabric was not tallied on needed timestep");
+
+  // grow local stress array if necessary
+  // needs to be atom->nmax in length
+
+  if (atom->nmax > nmax) {
+    memory->destroy(fabric);
+    nmax = atom->nmax;
+    memory->create(fabric,nmax,9,"fabric/atom:fabric");
+    array_atom = fabric;
+  }
+
+  // npair includes ghosts if either newton flag is set
+  //   b/c some bonds/dihedrals call pair::ev_tally with pairwise info
+  // nbond includes ghosts if newton_bond is set
+  // ntotal includes ghosts if either newton flag is set
+  // KSpace includes ghosts if tip4pflag is set
+
+  int nlocal = atom->nlocal;
+  int npair = nlocal;
+  int nbond = nlocal;
+  int ntotal = nlocal;
+  int nkspace = nlocal;
+  if (force->newton) npair += atom->nghost;
+
+  // clear local fabric array
+
+  for (i = 0; i < ntotal; i++)
+    for (j = 0; j < 9; j++)
+      fabric[i][j] = 0.0;
+
+  // add in per-atom contributions from each force
+
+  if (pairflag && force->pair) {
+    double **fabricatom = force->pair->fabricatom;
+    int *ncontact = force->pair->ncontact;
+    for (i = 0; i < npair; i++)
+      for (j = 0; j < 9; j++)
+        fabric[i][j] += fabricatom[i][j]/ncontact[i];
+  }
+
+  // communicate ghost virials between neighbor procs
+
+  if (force->newton || (force->kspace && force->kspace->tip4pflag))
+    comm->reverse_comm_compute(this);
+
+  // zero virial of atoms not in group
+  // only do this after comm since ghost contributions must be included
+
+  int *mask = atom->mask;
+
+  for (i = 0; i < nlocal; i++)
+    if (!(mask[i] & groupbit)) {
+      fabric[i][0] = 0.0;
+      fabric[i][1] = 0.0;
+      fabric[i][2] = 0.0;
+      fabric[i][3] = 0.0;
+      fabric[i][4] = 0.0;
+      fabric[i][5] = 0.0;
+      fabric[i][6] = 0.0;
+      fabric[i][7] = 0.0;
+      fabric[i][8] = 0.0;
+    }
+
+}
+
+/* ---------------------------------------------------------------------- */
+
+int ComputeFabricAtom::pack_reverse_comm(int n, int first, double *buf)
+{
+  int i,m,last;
+
+  m = 0;
+  last = first + n;
+  for (i = first; i < last; i++) {
+    buf[m++] = fabric[i][0];
+    buf[m++] = fabric[i][1];
+    buf[m++] = fabric[i][2];
+    buf[m++] = fabric[i][3];
+    buf[m++] = fabric[i][4];
+    buf[m++] = fabric[i][5];
+    buf[m++] = fabric[i][6];
+    buf[m++] = fabric[i][7];
+    buf[m++] = fabric[i][8];
+  }
+  return 9;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeFabricAtom::unpack_reverse_comm(int n, int *list, double *buf)
+{
+  int i,j,m;
+
+  m = 0;
+  for (i = 0; i < n; i++) {
+    j = list[i];
+    fabric[j][0] += buf[m++];
+    fabric[j][1] += buf[m++];
+    fabric[j][2] += buf[m++];
+    fabric[j][3] += buf[m++];
+    fabric[j][4] += buf[m++];
+    fabric[j][5] += buf[m++];
+    fabric[j][6] += buf[m++];
+    fabric[j][7] += buf[m++];
+    fabric[j][8] += buf[m++];
+  }
+}
+
+/* ----------------------------------------------------------------------
+   memory usage of local atom-based array
+------------------------------------------------------------------------- */
+
+double ComputeFabricAtom::memory_usage()
+{
+  double bytes = nmax*9 * sizeof(double);
+  return bytes;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int ComputeFabricAtom::pack_comm(int n, int *list, double *buf,
+                             int pbc_flag, int *pbc)
+{
+    int i,j;
+    //we dont need to account for pbc here
+    int m = 0;
+    for (i = 0; i < n; i++) {
+      j = list[i];
+      buf[m++] = fabric[j][0];
+      buf[m++] = fabric[j][1];
+      buf[m++] = fabric[j][2];
+      buf[m++] = fabric[j][3];
+      buf[m++] = fabric[j][4];
+      buf[m++] = fabric[j][5];
+      buf[m++] = fabric[j][6];
+      buf[m++] = fabric[j][7];
+      buf[m++] = fabric[j][8];
+    }
+    return 9;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeFabricAtom::unpack_comm(int n, int first, double *buf)
+{
+  int i,m,last;
+  m = 0;
+  last = first + n;
+  for (i = first; i < last; i++) {
+      fabric[i][0] = buf[m++];
+      fabric[i][1] = buf[m++];
+      fabric[i][2] = buf[m++];
+      fabric[i][3] = buf[m++];
+      fabric[i][4] = buf[m++];
+      fabric[i][5] = buf[m++];
+      fabric[i][6] = buf[m++];
+      fabric[i][7] = buf[m++];
+      fabric[i][8] = buf[m++];
+  }
+
+}

--- a/src/compute_fabric_atom.cpp
+++ b/src/compute_fabric_atom.cpp
@@ -153,8 +153,9 @@ void ComputeFabricAtom::compute_peratom()
     double **fabricatom = force->pair->fabricatom;
     int *ncontact = force->pair->ncontact;
     for (i = 0; i < npair; i++)
-      for (j = 0; j < 9; j++)
-        fabric[i][j] += fabricatom[i][j]/ncontact[i];
+      if (ncontact[i] > 0)
+        for (j = 0; j < 9; j++)
+          fabric[i][j] += fabricatom[i][j]/ncontact[i];
   }
 
   // communicate ghost virials between neighbor procs

--- a/src/compute_fabric_atom.h
+++ b/src/compute_fabric_atom.h
@@ -1,0 +1,103 @@
+/* ----------------------------------------------------------------------
+    This is the
+
+    ██╗     ██╗ ██████╗  ██████╗  ██████╗ ██╗  ██╗████████╗███████╗
+    ██║     ██║██╔════╝ ██╔════╝ ██╔════╝ ██║  ██║╚══██╔══╝██╔════╝
+    ██║     ██║██║  ███╗██║  ███╗██║  ███╗███████║   ██║   ███████╗
+    ██║     ██║██║   ██║██║   ██║██║   ██║██╔══██║   ██║   ╚════██║
+    ███████╗██║╚██████╔╝╚██████╔╝╚██████╔╝██║  ██║   ██║   ███████║
+    ╚══════╝╚═╝ ╚═════╝  ╚═════╝  ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝®
+
+    DEM simulation engine, released by
+    DCS Computing Gmbh, Linz, Austria
+    http://www.dcs-computing.com, office@dcs-computing.com
+
+    LIGGGHTS® is part of CFDEM®project:
+    http://www.liggghts.com | http://www.cfdem.com
+
+    Core developer and main author:
+    Christoph Kloss, christoph.kloss@dcs-computing.com
+
+    LIGGGHTS® is open-source, distributed under the terms of the GNU Public
+    License, version 2 or later. It is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. You should have
+    received a copy of the GNU General Public License along with LIGGGHTS®.
+    If not, see http://www.gnu.org/licenses . See also top-level README
+    and LICENSE files.
+
+    LIGGGHTS® and CFDEM® are registered trade marks of DCS Computing GmbH,
+    the producer of the LIGGGHTS® software and the CFDEM®coupling software
+    See http://www.cfdem.com/terms-trademark-policy for details.
+
+-------------------------------------------------------------------------
+    Contributing author and copyright for this file:
+    This file is from LAMMPS, but has been modified. Copyright for
+    modification:
+
+    Copyright 2012-     DCS Computing GmbH, Linz
+    Copyright 2009-2012 JKU Linz
+
+    Copyright of original file:
+    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+    http://lammps.sandia.gov, Sandia National Laboratories
+    Steve Plimpton, sjplimp@sandia.gov
+
+    Copyright (2003) Sandia Corporation.  Under the terms of Contract
+    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+    certain rights in this software.  This software is distributed under
+    the GNU General Public License.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+
+ComputeStyle(fabric/atom,ComputeFabricAtom)
+
+#else
+
+#ifndef LMP_COMPUTE_FABRIC_ATOM_H
+#define LMP_COMPUTE_FABRIC_ATOM_H
+
+#include "compute.h"
+
+namespace LAMMPS_NS {
+
+class ComputeFabricAtom : public Compute {
+ public:
+  ComputeFabricAtom(class LAMMPS *, int &iarg, int, char **);
+  ~ComputeFabricAtom();
+  void init() {}
+  void compute_peratom();
+  int pack_reverse_comm(int, int, double *);
+  void unpack_reverse_comm(int, int *, double *);
+  double memory_usage();
+
+  int pack_comm(int n, int *list, double *buf, int pbc_flag, int *pbc);
+  void unpack_comm(int n, int first, double *buf);
+
+ private:
+  int pairflag;
+  int nmax;
+  double **fabric;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Per-atom virial was not tallied on needed timestep
+
+You are using a thermo keyword that requires potentials to have
+tallied the virial, but they didn't on this timestep.  See the
+variable doc page for ideas on how to make this work.
+
+*/

--- a/src/compute_pair_gran_local.h
+++ b/src/compute_pair_gran_local.h
@@ -157,6 +157,11 @@ class ComputePairGranLocal : public Compute {
     return (msidflag > 0 ?   posflag*6+velflag*6+idflag*3+fflag*3+fnflag*3+ftflag*3+torqueflag*3+torquenflag*3+torquetflag*3+histflag*dnum+areaflag*1 + deltaflag*1 + heatflag*1 + cpflag*3 +1 : -1);
   }
 
+  virtual int offset_normal()
+  {
+    return (normalflag > 0 ?   posflag*6+velflag*6+idflag*3+fflag*3+fnflag*3+ftflag*3+torqueflag*3+torquenflag*3+torquetflag*3+histflag*dnum+areaflag*1 + deltaflag*1 + heatflag*1 + cpflag*3 + msidflag*2 : -1);
+  }
+
  protected:
 
   int nvalues;      // number of double values per entry
@@ -185,6 +190,8 @@ class ComputePairGranLocal : public Compute {
   int ipair;
 
   int posflag,velflag,idflag,fflag,fnflag,ftflag,torqueflag,torquenflag,torquetflag,histflag,areaflag,deltaflag,heatflag,cpflag,msidflag;
+
+  int normalflag;
 
   bool   verbose;
 

--- a/src/compute_strainenergy_atom.cpp
+++ b/src/compute_strainenergy_atom.cpp
@@ -1,0 +1,236 @@
+/* ----------------------------------------------------------------------
+    This is the
+
+    ██╗     ██╗ ██████╗  ██████╗  ██████╗ ██╗  ██╗████████╗███████╗
+    ██║     ██║██╔════╝ ██╔════╝ ██╔════╝ ██║  ██║╚══██╔══╝██╔════╝
+    ██║     ██║██║  ███╗██║  ███╗██║  ███╗███████║   ██║   ███████╗
+    ██║     ██║██║   ██║██║   ██║██║   ██║██╔══██║   ██║   ╚════██║
+    ███████╗██║╚██████╔╝╚██████╔╝╚██████╔╝██║  ██║   ██║   ███████║
+    ╚══════╝╚═╝ ╚═════╝  ╚═════╝  ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝®
+
+    DEM simulation engine, released by
+    DCS Computing Gmbh, Linz, Austria
+    http://www.dcs-computing.com, office@dcs-computing.com
+
+    LIGGGHTS® is part of CFDEM®project:
+    http://www.liggghts.com | http://www.cfdem.com
+
+    Core developer and main author:
+    Christoph Kloss, christoph.kloss@dcs-computing.com
+
+    LIGGGHTS® is open-source, distributed under the terms of the GNU Public
+    License, version 2 or later. It is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. You should have
+    received a copy of the GNU General Public License along with LIGGGHTS®.
+    If not, see http://www.gnu.org/licenses . See also top-level README
+    and LICENSE files.
+
+    LIGGGHTS® and CFDEM® are registered trade marks of DCS Computing GmbH,
+    the producer of the LIGGGHTS® software and the CFDEM®coupling software
+    See http://www.cfdem.com/terms-trademark-policy for details.
+
+-------------------------------------------------------------------------
+    Contributing author and copyright for this file:
+    This file is from LAMMPS, but has been modified. Copyright for
+    modification:
+
+    Copyright 2012-     DCS Computing GmbH, Linz
+    Copyright 2009-2012 JKU Linz
+
+    Copyright of original file:
+    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+    http://lammps.sandia.gov, Sandia National Laboratories
+    Steve Plimpton, sjplimp@sandia.gov
+
+    Copyright (2003) Sandia Corporation.  Under the terms of Contract
+    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+    certain rights in this software.  This software is distributed under
+    the GNU General Public License.
+------------------------------------------------------------------------- */
+
+#include <stdlib.h>
+#include <string.h>
+#include "compute_strainenergy_atom.h"
+#include "atom.h"
+#include "update.h"
+#include "comm.h"
+#include "force.h"
+#include "pair.h"
+#include "bond.h"
+#include "angle.h"
+#include "dihedral.h"
+#include "improper.h"
+#include "kspace.h"
+#include "modify.h"
+#include "fix.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace LAMMPS_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeStrainEnergyAtom::ComputeStrainEnergyAtom(LAMMPS *lmp, int &iarg, int narg, char **arg) :
+  Compute(lmp, iarg, narg, arg)
+{
+  if (narg < iarg) error->all(FLERR,"Illegal compute strainenergy/atom command");
+
+  peratom_flag = 1;
+  size_peratom_cols = 1;
+  pressatomflag = 1;
+  timeflag = 1;
+  comm_forward = 1;
+  comm_reverse = 1;
+
+  if (narg == iarg) {
+    pairflag = 1;
+  } else {
+    pairflag = 0;
+    while (iarg < narg) {
+      if (strcmp(arg[iarg],"pair") == 0) pairflag = 1;
+      else if (strcmp(arg[iarg],"virial") == 0) {
+        pairflag = 1;
+      } else error->all(FLERR,"Illegal compute strainenergy/atom command");
+      iarg++;
+    }
+  }
+
+  nmax = 0;
+  strainenergy = NULL;
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeStrainEnergyAtom::~ComputeStrainEnergyAtom()
+{
+  memory->destroy(strainenergy);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeStrainEnergyAtom::compute_peratom()
+{
+  int i,j;
+  double onemass;
+
+  invoked_peratom = update->ntimestep;
+  if (update->vflag_atom != invoked_peratom)
+    error->all(FLERR,"Per-atom strainenergy was not tallied on needed timestep");
+
+  // grow local stress array if necessary
+  // needs to be atom->nmax in length
+
+  if (atom->nmax > nmax) {
+    memory->destroy(strainenergy);
+    nmax = atom->nmax;
+    memory->create(strainenergy,nmax,1,"strainenergy/atom:strainenergy");
+    array_atom = strainenergy;
+  }
+
+  // npair includes ghosts if either newton flag is set
+  //   b/c some bonds/dihedrals call pair::ev_tally with pairwise info
+  // nbond includes ghosts if newton_bond is set
+  // ntotal includes ghosts if either newton flag is set
+  // KSpace includes ghosts if tip4pflag is set
+
+  int nlocal = atom->nlocal;
+  int npair = nlocal;
+  int nbond = nlocal;
+  int ntotal = nlocal;
+  int nkspace = nlocal;
+  if (force->newton) npair += atom->nghost;
+
+  // clear local strainenergy array
+
+  for (i = 0; i < ntotal; i++)
+    strainenergy[i][0] = 0.0;
+
+  // add in per-atom contributions from each force
+
+  if (pairflag && force->pair) {
+    double *seatom = force->pair->seatom;
+    for (i = 0; i < npair; i++)
+      strainenergy[i][0] += seatom[i];
+  }
+
+  // communicate ghost virials between neighbor procs
+
+  if (force->newton || (force->kspace && force->kspace->tip4pflag))
+    comm->reverse_comm_compute(this);
+
+  // zero virial of atoms not in group
+  // only do this after comm since ghost contributions must be included
+
+  int *mask = atom->mask;
+
+  for (i = 0; i < nlocal; i++)
+    if (!(mask[i] & groupbit)) {
+      strainenergy[i][0] = 0.0;
+    }
+
+}
+
+/* ---------------------------------------------------------------------- */
+
+int ComputeStrainEnergyAtom::pack_reverse_comm(int n, int first, double *buf)
+{
+  int i,m,last;
+
+  m = 0;
+  last = first + n;
+  for (i = first; i < last; i++) {
+    buf[m++] = strainenergy[i][0];
+  }
+  return 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeStrainEnergyAtom::unpack_reverse_comm(int n, int *list, double *buf)
+{
+  int i,j,m;
+
+  m = 0;
+  for (i = 0; i < n; i++) {
+    j = list[i];
+    strainenergy[j][0] += buf[m++];
+  }
+}
+
+/* ----------------------------------------------------------------------
+   memory usage of local atom-based array
+------------------------------------------------------------------------- */
+
+double ComputeStrainEnergyAtom::memory_usage()
+{
+  double bytes = nmax*1 * sizeof(double);
+  return bytes;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int ComputeStrainEnergyAtom::pack_comm(int n, int *list, double *buf,
+                             int pbc_flag, int *pbc)
+{
+    int i,j;
+    //we dont need to account for pbc here
+    int m = 0;
+    for (i = 0; i < n; i++) {
+      j = list[i];
+      buf[m++] = strainenergy[j][0];
+    }
+    return 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeStrainEnergyAtom::unpack_comm(int n, int first, double *buf)
+{
+  int i,m,last;
+  m = 0;
+  last = first + n;
+  for (i = first; i < last; i++) {
+      strainenergy[i][0] = buf[m++];
+  }
+}

--- a/src/compute_strainenergy_atom.h
+++ b/src/compute_strainenergy_atom.h
@@ -1,0 +1,103 @@
+/* ----------------------------------------------------------------------
+    This is the
+
+    ██╗     ██╗ ██████╗  ██████╗  ██████╗ ██╗  ██╗████████╗███████╗
+    ██║     ██║██╔════╝ ██╔════╝ ██╔════╝ ██║  ██║╚══██╔══╝██╔════╝
+    ██║     ██║██║  ███╗██║  ███╗██║  ███╗███████║   ██║   ███████╗
+    ██║     ██║██║   ██║██║   ██║██║   ██║██╔══██║   ██║   ╚════██║
+    ███████╗██║╚██████╔╝╚██████╔╝╚██████╔╝██║  ██║   ██║   ███████║
+    ╚══════╝╚═╝ ╚═════╝  ╚═════╝  ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚══════╝®
+
+    DEM simulation engine, released by
+    DCS Computing Gmbh, Linz, Austria
+    http://www.dcs-computing.com, office@dcs-computing.com
+
+    LIGGGHTS® is part of CFDEM®project:
+    http://www.liggghts.com | http://www.cfdem.com
+
+    Core developer and main author:
+    Christoph Kloss, christoph.kloss@dcs-computing.com
+
+    LIGGGHTS® is open-source, distributed under the terms of the GNU Public
+    License, version 2 or later. It is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. You should have
+    received a copy of the GNU General Public License along with LIGGGHTS®.
+    If not, see http://www.gnu.org/licenses . See also top-level README
+    and LICENSE files.
+
+    LIGGGHTS® and CFDEM® are registered trade marks of DCS Computing GmbH,
+    the producer of the LIGGGHTS® software and the CFDEM®coupling software
+    See http://www.cfdem.com/terms-trademark-policy for details.
+
+-------------------------------------------------------------------------
+    Contributing author and copyright for this file:
+    This file is from LAMMPS, but has been modified. Copyright for
+    modification:
+
+    Copyright 2012-     DCS Computing GmbH, Linz
+    Copyright 2009-2012 JKU Linz
+
+    Copyright of original file:
+    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+    http://lammps.sandia.gov, Sandia National Laboratories
+    Steve Plimpton, sjplimp@sandia.gov
+
+    Copyright (2003) Sandia Corporation.  Under the terms of Contract
+    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+    certain rights in this software.  This software is distributed under
+    the GNU General Public License.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+
+ComputeStyle(strainenergy/atom,ComputeStrainEnergyAtom)
+
+#else
+
+#ifndef LMP_COMPUTE_STRAIN_ENERGY_ATOM_H
+#define LMP_COMPUTE_STRAIN_ENERGY_ATOM_H
+
+#include "compute.h"
+
+namespace LAMMPS_NS {
+
+class ComputeStrainEnergyAtom : public Compute {
+ public:
+  ComputeStrainEnergyAtom(class LAMMPS *, int &iarg, int, char **);
+  ~ComputeStrainEnergyAtom();
+  void init() {}
+  void compute_peratom();
+  int pack_reverse_comm(int, int, double *);
+  void unpack_reverse_comm(int, int *, double *);
+  double memory_usage();
+
+  int pack_comm(int n, int *list, double *buf, int pbc_flag, int *pbc);
+  void unpack_comm(int n, int first, double *buf);
+
+ private:
+  int pairflag;
+  int nmax;
+  double **strainenergy;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running LAMMPS to see the offending line.
+
+E: Per-atom virial was not tallied on needed timestep
+
+You are using a thermo keyword that requires potentials to have
+tallied the virial, but they didn't on this timestep.  See the
+variable doc page for ideas on how to make this work.
+
+*/

--- a/src/contact_interface.h
+++ b/src/contact_interface.h
@@ -64,7 +64,7 @@ struct SurfacesCloseData {
   double radj;
   double radsum;
   double rsq;
-  double delta[3];  
+  double delta[3];
 
   double area_ratio;
 
@@ -133,9 +133,9 @@ struct SurfacesCloseData {
 
 struct SurfacesIntersectData : SurfacesCloseData {
 
-  double r;         
-  double rinv;      
-  double en[3];     
+  double r;
+  double rinv;
+  double en[3];
 
   double kt;
   double kn;
@@ -147,21 +147,22 @@ struct SurfacesIntersectData : SurfacesCloseData {
 
   double vn;
   double deltan;
-  double cri;   
-  double crj;   
-  double wr1;   
+  double deltat;
+  double cri;
+  double crj;
+  double wr1;
   double wr2;
   double wr3;
 
-  double vtr1;  
+  double vtr1;
   double vtr2;
   double vtr3;
 
-  double mi;    
+  double mi;
   double mj;
-  double meff;  
+  double meff;
 
-  mutable double P_diss; 
+  mutable double P_diss;
 
   SurfacesIntersectData() : Fn(0.0), Ft(0.0) {}
 };

--- a/src/dump_local_gran.cpp
+++ b/src/dump_local_gran.cpp
@@ -85,7 +85,7 @@
 using namespace LAMMPS_NS;
 
 enum{INT,DOUBLE,STRING}; // same as in DumpCFG
-enum{X1,X2,CP,V1,V2,ID1,ID2,F,FN,FT,TORQUE,TORQUEN,TORQUET,AREA,DELTA,HEAT,MSID1,MSID2}; // dumps positions, force, normal and tangential forces, torque, normal and tangential torque
+enum{X1,X2,CP,V1,V2,ID1,ID2,F,FN,FT,TORQUE,TORQUEN,TORQUET,AREA,DELTA,HEAT,MSID1,MSID2,NORMAL}; // dumps positions, force, normal and tangential forces, torque, normal and tangential torque
 
 /* ---------------------------------------------------------------------- */
 
@@ -197,7 +197,7 @@ void DumpLocalGran::init_style()
 
 int DumpLocalGran::count()
 {
-    
+
     n_calls_ = 0;
 
     //TODO generalize
@@ -214,7 +214,7 @@ int DumpLocalGran::count()
 
 void DumpLocalGran::prepare_mbSet(vtkSmartPointer<vtkMultiBlockDataSet> mbSet, bool use_poly_data)
 {
-    
+
     // nme = # of dump lines this proc contributes to dump
 
     int nme = count();
@@ -240,7 +240,7 @@ void DumpLocalGran::prepare_mbSet(vtkSmartPointer<vtkMultiBlockDataSet> mbSet, b
         maxbuf = nmax;
         memory->destroy(buf);
         memory->create(buf,maxbuf*size_one,"dump:buf");
-        
+
     }
 
     // ensure ids buffer is sized for sorting
@@ -311,7 +311,7 @@ void DumpLocalGran::pack(int *ids)
 
 void DumpLocalGran::buf2arrays(int n, double *mybuf)
 {
-    
+
     const bool have_cp = cpgl_->offset_contact_point() >= 0;
 
     for (int idata=0; idata < n; ++idata) {
@@ -593,7 +593,7 @@ void DumpLocalGran::define_properties()
 
     if(cpgl_->offset_area() >= 0)
     {
-            
+
             pack_choice[AREA] = &DumpLocalGran::pack_area;
             vtype[AREA] = DOUBLE;
             name[AREA] = "contact_area";
@@ -630,6 +630,14 @@ void DumpLocalGran::define_properties()
             vtype[MSID2] = DOUBLE;
             name[MSID2] = "ms_id2";
             //scalar
+    }
+
+    if(cpgl_->offset_normal() >= 0)
+    {
+            pack_choice[NORMAL] = &DumpLocalGran::pack_normal;
+            vtype[NORMAL] = DOUBLE;
+            name[NORMAL] = "normal";
+            vector_set.insert(NORMAL);
     }
 }
 
@@ -861,6 +869,16 @@ void DumpLocalGran::pack_ms_id2(int n)
 
     for (int i = 0; i < nchoose; i++) {
         buf[n] = cpgl_->get_data()[i][offset];
+        n += size_one;
+    }
+}
+
+void DumpLocalGran::pack_normal(int n)
+{
+    int offset = cpgl_->offset_normal();
+
+    for (int i = 0; i < nchoose; i++) {
+        vectorCopy3D(&cpgl_->get_data()[i][offset],&buf[n]);
         n += size_one;
     }
 }

--- a/src/dump_local_gran.h
+++ b/src/dump_local_gran.h
@@ -40,7 +40,7 @@
     Copyright 2016-     DCS Computing GmbH, Linz
 ------------------------------------------------------------------------- */
 
-#if defined(LAMMPS_VTK) 
+#if defined(LAMMPS_VTK)
 
 #ifndef LMP_DUMP_LOCAL_GRAN_H
 #define LMP_DUMP_LOCAL_GRAN_H
@@ -120,7 +120,7 @@ class DumpLocalGran : public Pointers {
 
     void define_properties();
     typedef void (DumpLocalGran::*FnPtrPack)(int);
-    
+
     std::map<int, FnPtrPack> pack_choice;   // ptrs to pack functions
     std::map<int, int> vtype;               // data type for each attribute
     std::map<int, std::string> name;        // label for each attribute
@@ -155,6 +155,7 @@ class DumpLocalGran : public Pointers {
     void pack_contact_point(int);
     void pack_ms_id1(int);
     void pack_ms_id2(int);
+    void pack_normal(int);
 };
 
 }

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -1044,7 +1044,10 @@ void Pair::ev_tally_xyz(int i, int j, int nlocal, int newton_pair,
     ftangent[1] = fy - fn * normal[1];
     ftangent[2] = fz - fn * normal[2];
     ft = vectorMag3D(ftangent);
-    strain_energy = (alpha)/(alpha+1.0)*fn*fn/kn + 0.5*ft*ft/kt;
+
+    double normal_energy = (kn > std::numeric_limits<double>::epsilon()) ? (alpha)/(alpha+1.0)*fn*fn/kn : 0.0;
+    double tangential_energy = (kt > std::numeric_limits<double>::epsilon()) ? 0.5*ft*ft/kt : 0.0;
+    strain_energy = normal_energy + tangential_energy;
 
     if (vflag_global) {
       if (newton_pair) {

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -1045,8 +1045,8 @@ void Pair::ev_tally_xyz(int i, int j, int nlocal, int newton_pair,
     ftangent[2] = fz - fn * normal[2];
     ft = vectorMag3D(ftangent);
 
-    double normal_energy = (kn > std::numeric_limits<double>::epsilon()) ? (alpha)/(alpha+1.0)*fn*fn/kn : 0.0;
-    double tangential_energy = (kt > std::numeric_limits<double>::epsilon()) ? 0.5*ft*ft/kt : 0.0;
+    double normal_energy = (std::abs(kn) > std::numeric_limits<double>::epsilon()) ? (alpha)/(alpha+1.0)*fn*fn/std::abs(kn) : 0.0;
+    double tangential_energy = (std::abs(kt) > std::numeric_limits<double>::epsilon()) ? 0.5*ft*ft/std::abs(kt) : 0.0;
     strain_energy = normal_energy + tangential_energy;
 
     if (vflag_global) {

--- a/src/pair.h
+++ b/src/pair.h
@@ -66,6 +66,9 @@ class Pair : protected Pointers {
   double virial[6];              // accumulated virial
   double *eatom,**vatom;         // accumulated per-atom energy/virial
 
+  double **fabricatom;           // accumulated fabric
+  int *ncontact;                 // total number of atom contact
+
   double cutforce;               // max cutoff for all atom pairs
   double **cutsq;                // cutoff sq for each atom pair
   int **setflag;                 // 0/1 = whether each i,j has been set
@@ -97,7 +100,7 @@ class Pair : protected Pointers {
 
   int evflag;                    // energy,virial settings
   int eflag_either,eflag_global,eflag_atom;
-  int vflag_either,vflag_global,vflag_atom;
+  int vflag_either,vflag_global,vflag_atom,fabricflag_atom;
 
   int ncoultablebits;            // size of Coulomb table, accessed by KSpace
   int ndisptablebits;            // size of dispersion table
@@ -225,7 +228,7 @@ class Pair : protected Pointers {
   double THIRD;
 
   int vflag_fdotr;
-  int maxeatom,maxvatom;
+  int maxeatom,maxvatom,maxfabricatom;
 
   virtual void ev_setup(int, int);
   void ev_unset();

--- a/src/pair.h
+++ b/src/pair.h
@@ -69,6 +69,8 @@ class Pair : protected Pointers {
   double **fabricatom;           // accumulated fabric
   int *ncontact;                 // total number of atom contact
 
+  double *seatom;                // accumulated strain energy
+
   double cutforce;               // max cutoff for all atom pairs
   double **cutsq;                // cutoff sq for each atom pair
   int **setflag;                 // 0/1 = whether each i,j has been set
@@ -100,7 +102,7 @@ class Pair : protected Pointers {
 
   int evflag;                    // energy,virial settings
   int eflag_either,eflag_global,eflag_atom;
-  int vflag_either,vflag_global,vflag_atom,fabricflag_atom;
+  int vflag_either,vflag_global,vflag_atom,fabricflag_atom,seflag_atom;
 
   int ncoultablebits;            // size of Coulomb table, accessed by KSpace
   int ndisptablebits;            // size of dispersion table
@@ -157,7 +159,7 @@ class Pair : protected Pointers {
   void v_tally4(int, int, int, int, double *, double *, double *,
                 double *, double *, double *);
   void ev_tally_xyz(int, int, int, int, double, double,
-                    double, double, double, double, double, double);
+                    double, double, double, double, double, double, double, double);
 
   // general child-class methods
 
@@ -228,7 +230,7 @@ class Pair : protected Pointers {
   double THIRD;
 
   int vflag_fdotr;
-  int maxeatom,maxvatom,maxfabricatom;
+  int maxeatom,maxvatom,maxfabricatom,maxseatom;
 
   virtual void ev_setup(int, int);
   void ev_unset();

--- a/src/pair_gran_base.h
+++ b/src/pair_gran_base.h
@@ -447,7 +447,7 @@ public:
             pg->cpl_add_pair(sidata, i_forces);
 
           if (pg->evflag)
-            pg->ev_tally_xyz(i, j, nlocal, newton_pair, 0.0, 0.0,i_forces.delta_F[0],i_forces.delta_F[1],i_forces.delta_F[2],sidata.delta[0],sidata.delta[1],sidata.delta[2], sidata.kn*sidata.deltan, sidata.kt*sidata.deltat);
+            pg->ev_tally_xyz(i, j, nlocal, newton_pair, 0.0, 0.0,i_forces.delta_F[0],i_forces.delta_F[1],i_forces.delta_F[2],sidata.delta[0],sidata.delta[1],sidata.delta[2], sidata.kn, sidata.kt);
 
           if (store_contact_forces && 0 == update->ntimestep % pg->storeContactForcesEvery())
           {

--- a/src/pair_gran_base.h
+++ b/src/pair_gran_base.h
@@ -447,7 +447,7 @@ public:
             pg->cpl_add_pair(sidata, i_forces);
 
           if (pg->evflag)
-            pg->ev_tally_xyz(i, j, nlocal, newton_pair, 0.0, 0.0,i_forces.delta_F[0],i_forces.delta_F[1],i_forces.delta_F[2],sidata.delta[0],sidata.delta[1],sidata.delta[2], sidata.kn, sidata.kt);
+            pg->ev_tally_xyz(i, j, nlocal, newton_pair, 0.0, 0.0,i_forces.delta_F[0],i_forces.delta_F[1],i_forces.delta_F[2],sidata.delta[0],sidata.delta[1],sidata.delta[2], sidata.kn*sidata.deltan, sidata.kt*sidata.deltat);
 
           if (store_contact_forces && 0 == update->ntimestep % pg->storeContactForcesEvery())
           {

--- a/src/pair_gran_base.h
+++ b/src/pair_gran_base.h
@@ -333,7 +333,7 @@ public:
 
         // rsq < radsum * radsum is broad phase check with bounding spheres
         // cmodel.checkSurfaceIntersect() is narrow phase check
-        
+
         #ifdef SUPERQUADRIC_ACTIVE_FLAG
         if (rmass) {
           sidata.mi = rmass[i];
@@ -394,7 +394,7 @@ public:
           sidata.meff = meff;
           sidata.mi = mi;
           sidata.mj = mj;
-          
+
           if(atom->sphere_flag) {
               sidata.en[0]   = enx_sphere;
               sidata.en[1]   = eny_sphere;
@@ -447,7 +447,7 @@ public:
             pg->cpl_add_pair(sidata, i_forces);
 
           if (pg->evflag)
-            pg->ev_tally_xyz(i, j, nlocal, newton_pair, 0.0, 0.0,i_forces.delta_F[0],i_forces.delta_F[1],i_forces.delta_F[2],sidata.delta[0],sidata.delta[1],sidata.delta[2]);
+            pg->ev_tally_xyz(i, j, nlocal, newton_pair, 0.0, 0.0,i_forces.delta_F[0],i_forces.delta_F[1],i_forces.delta_F[2],sidata.delta[0],sidata.delta[1],sidata.delta[2], sidata.kn, sidata.kt);
 
           if (store_contact_forces && 0 == update->ntimestep % pg->storeContactForcesEvery())
           {

--- a/src/tangential_model_base.h
+++ b/src/tangential_model_base.h
@@ -61,7 +61,7 @@ class TangentialModelBase : protected Pointers
     virtual void registerSettings(Settings& settings) = 0;
     virtual void postSettings(IContactHistorySetup * hsetup, ContactModelBase *cmb) = 0;
     virtual void connectToProperties(PropertyRegistry&) = 0;
-    virtual void surfacesIntersect(const SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces) = 0;
+    virtual void surfacesIntersect(SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces) = 0;
     virtual void surfacesClose(SurfacesCloseData &scdata, ForceData&, ForceData&) = 0;
     virtual void beginPass(SurfacesIntersectData&, ForceData&, ForceData&) = 0;
     virtual void endPass(SurfacesIntersectData&, ForceData&, ForceData&) = 0;
@@ -76,7 +76,7 @@ class TangentialModelBase : protected Pointers
     inline void endPass(SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces);
     inline void registerSettings(Settings & settings);
     inline void connectToProperties(PropertyRegistry & registry);
-    inline void surfacesIntersect(const SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces);
+    inline void surfacesIntersect(SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces);
     inline void surfacesClose(SurfacesCloseData & scdata, ForceData & i_forces, ForceData & j_forces);
   };
 
@@ -89,7 +89,7 @@ class TangentialModelBase : protected Pointers
     void endPass(SurfacesIntersectData&, ForceData&, ForceData&){}
     void connectToProperties(PropertyRegistry&){}
     void registerSettings(Settings&){}
-    void surfacesIntersect(const SurfacesIntersectData&, ForceData&, ForceData&){}
+    void surfacesIntersect(SurfacesIntersectData&, ForceData&, ForceData&){}
     void surfacesClose(SurfacesCloseData&, ForceData&, ForceData&){}
     inline void postSettings(IContactHistorySetup * hsetup, ContactModelBase *cmb) {}
   };

--- a/src/tangential_model_luding_tn.h
+++ b/src/tangential_model_luding_tn.h
@@ -102,7 +102,7 @@ namespace ContactModels
       registry.connect("kT2kcMax", kT2kcMax,"tangential_model tan_luding");
      }
 
-    inline void surfacesIntersect(const SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces)
+    inline void surfacesIntersect(SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces)
     {
       const double enx = sidata.en[0];
       const double eny = sidata.en[1];
@@ -128,6 +128,7 @@ namespace ContactModels
       }
 
       const double shrmag = sqrt(shear[0]*shear[0] + shear[1]*shear[1] + shear[2]*shear[2]);
+      sidata.deltat = shrmag;
 
       const double xmuS = coeffFrict[sidata.itype][sidata.jtype];                   //coefficient of sliding friction
       const double xmuD = xmuS * coeffMu[sidata.itype][sidata.jtype];               //coefficient of dynamic friction

--- a/src/tangential_model_no_history.h
+++ b/src/tangential_model_no_history.h
@@ -71,7 +71,7 @@ namespace ContactModels
       dissipatedflag_(false),
       fix_dissipated_(NULL)
     {
-      
+
     }
 
     inline void registerSettings(Settings &settings)
@@ -109,13 +109,16 @@ namespace ContactModels
       registry.connect("coeffFrict", coeffFrict,"tangential_model history");
     }
 
-    inline void surfacesIntersect(const SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces) {
+    inline void surfacesIntersect(SurfacesIntersectData & sidata, ForceData & i_forces, ForceData & j_forces) {
       if(sidata.contact_flags) *sidata.contact_flags |= CONTACT_TANGENTIAL_MODEL;
       const double xmu = coeffFrict[sidata.itype][sidata.jtype];
       const double enx = sidata.en[0];
       const double eny = sidata.en[1];
       const double enz = sidata.en[2];
       const double vrel = sqrt(sidata.vtr1*sidata.vtr1 + sidata.vtr2*sidata.vtr2 + sidata.vtr3*sidata.vtr3);
+      const double dt = update->dt;
+      const double deltat = vrel * dt;
+      sidata.deltat = deltat;
 
       // force normalization
       const double Ft_friction = xmu * fabs(sidata.Fn);


### PR DESCRIPTION
A PR to develop for micro-to-macro model considering fabric.

## Contact normals
A way to visualize the normal vector of each contact has been added. The following commands are used in the input file to visualize them as a VTK file.
```
# Compute pair/gran/local
compute cpgl all pair/gran/local pos vel force normal
dump dmp3 all local/gran/vtk 1000 results/normal_contact*.vtk cpgl
```

## Computing Fabric
We can use to compute fabric directly by using a particle sum.
```
# Compute fabric/atom
compute 2 all fabric/atom
compute fab all reduce sum c_2[1] c_2[2] c_2[3] c_2[4] c_2[5] c_2[6] c_2[7] c_2[8] c_2[9]
thermo_style	custom step atoms c_fab[1] c_fab[2] c_fab[3] c_fab[4] c_fab[5] c_fab[6] c_fab[7] c_fab[8] c_fab[9]
```
The obtained summed of fabric tensor should be divided with the total number of atom to normalize the magnitude.

## Computing Strain Energy
Similarly, a new implementation to compute strain energy is performed following this equation:
![image](https://user-images.githubusercontent.com/37140224/202027715-f907daa1-fde8-443b-96c5-9d73469a5736.png)
Here, alpha is assumed to be 3/2.
```
# Compute strainenergy/atom
compute 3 all strainenergy/atom
compute senergy all reduce sum c_3[1] 
thermo_style custom step atoms c_senergy
```